### PR TITLE
CKEditor 4.1 OEmbed fix

### DIFF
--- a/oembed/plugin.js
+++ b/oembed/plugin.js
@@ -47,8 +47,7 @@
                         jQuery('body').oembed(inputCode, {
                             onEmbed: function(e) {
                                 if (typeof e.code === 'string') {
-                                    editorInstance.insertHtml(editor.config.oembed_WrapperClass != null ? '<div class="' + editor.config.oembed_WrapperClass + '" />' : '<div />');
-                                    editorInstance.insertHtml(e.code);
+                                    editorInstance.insertHtml(editor.config.oembed_Wrapper != null ? $('<div>').append($(editor.config.oembed_Wrapper).append(e.code)).html() : e.code);
                                     
                                     CKEDITOR.dialog.getCurrent().hide();
                                 } else {


### PR DESCRIPTION
Fixed the "Uncaught TypeError: Cannot read property 'isBlock' of undefined" error thrown by the plugin in the CKEditor 4.1.

Also changes the config.oembed_WrapperClass to config.oembed_Wrapper, and from now on you can also specify any custom tag, style and/or class for the wrapping element like:

config.oembed_Wrapper = '&lt;p style="text-align:center"&gt;';
