### PR TITLE
Error Handling for ajax: no response

### DIFF
--- a/oembed/libs/jquery.oembed.js
+++ b/oembed/libs/jquery.oembed.js
@@ -122,7 +122,7 @@
         afterEmbed: function() {},
         onEmbed: false,
         onError: function() {},
-        ajaxOptions: {}
+        ajaxOptions: { timeout: 2000 }
     };
     
     /*
@@ -243,7 +243,9 @@
             oembedData.code = result;
             success(oembedData, externalUrl, container);
           },
-          error: settings.onError.call(container, externalUrl, embedProvider)
+          error: function () {
+            settings.onError.call(container, externalUrl, embedProvider);
+          }
         }, settings.ajaxOptions || {});
         
         $.ajax(ajaxopts);
@@ -331,8 +333,10 @@
               oembedData.code = embedProvider.templateData(data);
               success(oembedData, externalUrl, container);
             },
-            error: settings.onError.call(container, externalUrl, embedProvider)
-            }, settings.ajaxOptions || {});
+            error: function () {
+              settings.onError.call(container, externalUrl, embedProvider);
+            }
+          }, settings.ajaxOptions || {});
             
           $.ajax( ajaxopts );
         }else {
@@ -362,7 +366,9 @@
                     }
                     success(oembedData, externalUrl, container);
                 },
-                error: settings.onError.call(container, externalUrl, embedProvider)
+                error: function () {
+                    settings.onError.call(container, externalUrl, embedProvider);
+                }
             }, settings.ajaxOptions || {});
 
         $.ajax(ajaxopts);

--- a/oembed/plugin.js
+++ b/oembed/plugin.js
@@ -139,6 +139,9 @@
                                     alert(editor.lang.oembed.noEmbedCode);
                                 }
                             },
+                            onError: function (externalUrl, embedProvider) {
+                                alert("We could not access the video at \"" + externalUrl + "\". Check video settings and try again.");
+                            },
                             maxHeight: maxHeight,
                             maxWidth: maxWidth,
                             useResponsiveResize: responsiveResize,


### PR DESCRIPTION
There are cases where the $.ajax(ajaxopts) call will not receive a
response. One such instance that we found is where the vimeo video is
protected (not embeddable). Test url: http://vimeo.com/7968917. Adding a
default timeout will allow such errors to be caught by the plugin's
error function.

Also, the onError callback stubs were not inside a function wrapper,
which caused the error function to execute before the ajax call was
made. The reason this was probably not observed until now was that the
default error function was empty.
