### PR TITLE
Removed the trailing commas that broke Internet Explorer 6-9.

### DIFF
--- a/oembed/plugin.js
+++ b/oembed/plugin.js
@@ -286,13 +286,13 @@
                                                 id: 'maxWidth',
                                                 'default': editor.config.oembed_maxWidth != null ? editor.config.oembed_maxWidth : '560',
                                                 label: editor.lang.oembed.maxWidth,
-                                                title: editor.lang.oembed.maxWidthTitle,
+                                                title: editor.lang.oembed.maxWidthTitle
                                             }, {
                                                 type: 'text',
                                                 id: 'maxHeight',
                                                 'default': editor.config.oembed_maxHeight != null ? editor.config.oembed_maxHeight : '315',
                                                 label: editor.lang.oembed.maxHeight,
-                                                title: editor.lang.oembed.maxHeightTitle,
+                                                title: editor.lang.oembed.maxHeightTitle
                                             }]
                                     }, {
                                         type: 'hbox',
@@ -302,13 +302,13 @@
                                                 id: 'width',
                                                 'default': editor.config.oembed_maxWidth != null ? editor.config.oembed_maxWidth : '560',
                                                 label: editor.lang.oembed.width,
-                                                title: editor.lang.oembed.widthTitle,
+                                                title: editor.lang.oembed.widthTitle
                                             }, {
                                                 type: 'text',
                                                 id: 'height',
                                                 'default': editor.config.oembed_maxHeight != null ? editor.config.oembed_maxHeight : '315',
                                                 label: editor.lang.oembed.height,
-                                                title: editor.lang.oembed.heightTitle,
+                                                title: editor.lang.oembed.heightTitle
                                             }]
                                     }]
                             }, {


### PR DESCRIPTION
In Internet Explorer, you cannot end an object or array definition with a trailing comma. For example, both of the following lines of code will break IE:

var arr = [ 1, 2, 3, 4, ];

var obj = { a:1, b:2, c:3, };

Note that both arr and obj end with a comma. For more information, see: http://trailingcomma.com/
