### PR TITLE
Fix «resize» input positioning in Firefox.

### DIFF
--- a/oembed/plugin.js
+++ b/oembed/plugin.js
@@ -300,7 +300,7 @@
                                 title: editor.lang.oembed.pasteUrl
                             }, {
                                 type: 'hbox',
-
+                                widths: ['50%', 'auto', 'auto'],
                                 children: [{
                                         id: 'resizeType',
                                         type: 'select',


### PR DESCRIPTION
Set form element widths on the «resize» line to [50%, auto, auto], not [33%, 33%, 33%].
Fixes input positioning in FF.

This is not an ideal solution (there are still minor gaps), but now it is at least better that it was before.
