### PR TITLE
Remove BOM, add a ! after the start of the copyright/information comment.

### DIFF
--- a/oembed/plugin.js
+++ b/oembed/plugin.js
@@ -1,4 +1,4 @@
-﻿/*
+/*!
 * oEmbed Plugin plugin
 * Copyright (c) Ingo Herbote
 * Licensed under the MIT license


### PR DESCRIPTION
1) BOM isn't required per specification, and it is bad when you unite scripts with something that does not treat BOM (for example, «cat 1.js 2.js > result.js»), because in such situation BOM would occur in the middle of the resulting script, which is wrong.

2) Opening /\* for the copyright/information comment is replaced with /*!, thus instructing minification utilities (like yuicompressor) to preserve this comment as it is.
