### PR TITLE
Removed URI scheme from jQuery link

### DIFF
--- a/plugin.js
+++ b/plugin.js
@@ -125,7 +125,7 @@
 
             function loadjQueryLibaries() {
                 if (typeof(jQuery) === 'undefined') {
-                    CKEDITOR.scriptLoader.load('http://ajax.googleapis.com/ajax/libs/jquery/1/jquery.min.js', function() {
+                    CKEDITOR.scriptLoader.load('//ajax.googleapis.com/ajax/libs/jquery/1/jquery.min.js', function() {
                         jQuery.noConflict();
                         if (typeof(jQuery.fn.oembed) === 'undefined') {
                             CKEDITOR.scriptLoader.load(


### PR DESCRIPTION
When using this script on an https page, the script was blocked by default because it tried to load jQuery from an 'unsafe' locate (i.e. over http). By removing the URI scheme, the browser automatically applies the current page's scheme (i.e. http or https), and it works fine.
