### PR TITLE
Fix for CKEditor Builder

### DIFF
--- a/plugin.js
+++ b/plugin.js
@@ -100,8 +100,7 @@
                 editor.ui.addButton('oembed', {
                     label: editor.lang.oembed.button,
                     command: 'oembed',
-                    toolbar: 'insert,10',
-                    icon: this.path + "icons/" + (CKEDITOR.env.hidpi ? "hidpi/" : "") + "oembed.png"
+                    toolbar: 'insert,10'
                 });
 
                 var resizeTypeChanged = function() {


### PR DESCRIPTION
Removes the icon override so the CKEditor Builder can build the
icon.png sprite and use it accordingly.
